### PR TITLE
Rs482 command reading works

### DIFF
--- a/glider-flight-controller/CommandHandler.cpp
+++ b/glider-flight-controller/CommandHandler.cpp
@@ -1,0 +1,31 @@
+#include "CommandHandler.h"
+#include <Arduino.h>
+#include "Pins.h"
+
+extern HardwareSerial RS485;
+
+void CommandReceiveTask(void* param) {
+  String input;
+
+  while (true) {
+    while (RS485.available()) {
+      char c = RS485.read();
+      if (c == '\n') {
+        input.trim();
+        if (!input.isEmpty()) {
+          Serial.print("[RS485 CMD] ");
+          Serial.println(input);
+        }
+        input = "";
+      } else {
+        input += c;
+      }
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(10));
+  }
+}
+
+void startCommandReceiveTask() {
+  xTaskCreatePinnedToCore(CommandReceiveTask, "CommandReceiveTask", 4096, NULL, 1, NULL, 1);
+}

--- a/glider-flight-controller/CommandHandler.h
+++ b/glider-flight-controller/CommandHandler.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void startCommandReceiveTask();  // Starts the RS485 command receiver task

--- a/glider-flight-controller/Telemetry.cpp
+++ b/glider-flight-controller/Telemetry.cpp
@@ -88,6 +88,8 @@ void TelemetryTask(void* param) {
     // These can stay as placeholders for now
     actuators["pitchPosition"] = Pitch_position;
     actuators["rollPosition"] = Roll_position;
+    
+    doc["ready"] = true;  // Flag to signal ground station it's safe to send command now
 
     // Send over RS485 and USB for debug
     serializeJson(doc, RS485);

--- a/glider-flight-controller/glider-flight-controller.ino
+++ b/glider-flight-controller/glider-flight-controller.ino
@@ -1,12 +1,15 @@
+#include "Telemetry.h"
+#include "CommandHandler.h"
+#include <HardwareSerial.h>
 #include "Orientation.h"
 #include "CANHandler.h"
-#include "Telemetry.h"
-#include <HardwareSerial.h>
 #include "Pins.h"
 
-HardwareSerial RS485(2);
+// Shared RS485 interface used across tasks (defined here, used in .cpp files)
+HardwareSerial RS485(2);  // UART2 on ESP32 (ID = 2)
 
 void setup() {
+  RS485.begin(9600, SERIAL_8N1, RS485_RX, RS485_TX); // Init RS485
   Serial.begin(115200);
   delay(1000);
   Serial.println("Starting system...");
@@ -15,12 +18,15 @@ void setup() {
   initCAN();                    // Init CAN
   startCANReceiveTask();        // Start CAN read task
 
-  RS485.begin(9600, SERIAL_8N1, RS485_RX, RS485_TX); // Init RS485
+  
   Serial.println("RS485 initialized.");
 
   startTelemetryTask();         // Start telemetry task on Core 1
+  startCommandReceiveTask();    // Task that listens for RS485 commands and forwards them
+
+  Serial.println("[SETUP] All tasks launched.");
 }
 
 void loop() {
-
+  // Main loop is not used; all tasks run in parallel
 }


### PR DESCRIPTION
Added the functionality of reading the commands through the RS482 tether while maintaining CANBUS connectivity between the FC, 1 VBD and 1 BMS. The RS482 command still come through garbled, potentially due to the collisions of the data between the command from the GCS and the telemetry from the FC.